### PR TITLE
Configurator: Load DatabaseExtension only if it's available.

### DIFF
--- a/src/Bootstrap/Configurator.php
+++ b/src/Bootstrap/Configurator.php
@@ -193,7 +193,9 @@ class Configurator extends Object
 		$me = $this;
 		$factory->onCompile[] = function(DI\ContainerFactory $factory, DI\Compiler $compiler, $config) use ($me) {
 			foreach ($me->defaultExtensions as $name => $class) {
-				$compiler->addExtension($name, new $class);
+				if (class_exists($class)) {
+					$compiler->addExtension($name, new $class);
+				}
 			}
 			$factory->parentClass = $config['parameters']['container']['parent'];
 			$me->onCompile($me, $compiler);


### PR DESCRIPTION
`nette/database` is not required by `nette/bootstrap`, so `Configurator` should load `DatabaseExtension` only if it's really available.
