### PR TITLE
Configurator: fixed error when $_COOKIE['nette-debug'] contained array

### DIFF
--- a/src/Bootstrap/Configurator.php
+++ b/src/Bootstrap/Configurator.php
@@ -238,7 +238,7 @@ class Configurator extends Object
 	public static function detectDebugMode($list = NULL)
 	{
 		$addr = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : php_uname('n');
-		$secret = isset($_COOKIE['nette-debug']) ? $_COOKIE['nette-debug'] : NULL;
+		$secret = isset($_COOKIE['nette-debug']) && is_string($_COOKIE['nette-debug']) ? $_COOKIE['nette-debug'] : NULL;
 		$list = is_string($list) ? preg_split('#[,\s]+#', $list) : (array) $list;
 		if (!isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
 			$list[] = '127.0.0.1';

--- a/tests/Bootstrap/Configurator.debugMode.phpt
+++ b/tests/Bootstrap/Configurator.debugMode.phpt
@@ -87,4 +87,7 @@ test(function(){ // secret
 	Assert::true( Configurator::detectDebugMode('192.168.1.1') );
 	Assert::false( Configurator::detectDebugMode('abc@192.168.1.1') );
 	Assert::true( Configurator::detectDebugMode('*secret*@192.168.1.1') );
+
+	$_COOKIE['nette-debug'] = array('*secret*');
+	Assert::false( Configurator::detectDebugMode('*secret*@192.168.1.1') );
 });


### PR DESCRIPTION
Setting value to cookie `nette-debug[]` would always trigger error.
