### PR TITLE
Missing dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
 	],
 	"require": {
 		"php": ">=5.3.1",
+		"latte/latte": "~2.2",
 		"nette/di": "~2.2",
-		"nette/utils": "~2.2"
+		"nette/robot-loader": "~2.2",
+		"nette/utils": "~2.2",
+		"tracy/tracy": "~2.2"
 	},
 	"require-dev": {
 		"nette/application": "~2.2",
 		"nette/database": "~2.2",
 		"nette/mail": "~2.2",
-		"nette/robot-loader": "~2.2",
 		"nette/safe-stream": "~2.2",
 		"nette/security": "~2.2",
-		"latte/latte": "~2.2",
-		"tracy/tracy": "~2.2",
 		"nette/tester": "~1.0"
 	},
 	"conflict": {


### PR DESCRIPTION
There are a number of missing references to other Nette packages after the split and because of that, using `nette/bootsrap` as a dependency is really difficult.

The missing dependencies can be classified in two groups:
1) "hard" (static) dependencies, which are linked in the code
2) "soft" dependencies, which are used while generating the container

I think it makes sense to add both groups to "require", but I don't know if there is not a reason for this, so this PR is now just for the 1st group.

I know about issue #4 which states that this will be resolved in a cleaner way, but until then I think the dependencies should be added, when they are needed.

Should I include also the packages from group 2)?
Is there a reason for the `nette/database` dev dependency?
