### PR TITLE
nette/robot-loader is now optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,17 @@
 		"php": ">=5.3.1",
 		"latte/latte": "~2.2",
 		"nette/di": "~2.2",
-		"nette/robot-loader": "~2.2",
 		"nette/utils": "~2.2",
 		"tracy/tracy": "~2.2"
+	},
+	"suggest": {
+		"nette/robot-loader": "to use Configurator::createRobotLoader()"
 	},
 	"require-dev": {
 		"nette/application": "~2.2",
 		"nette/database": "~2.2",
 		"nette/mail": "~2.2",
+		"nette/robot-loader": "~2.2",
 		"nette/safe-stream": "~2.2",
 		"nette/security": "~2.2",
 		"nette/tester": "~1.0"

--- a/src/Bootstrap/Configurator.php
+++ b/src/Bootstrap/Configurator.php
@@ -141,9 +141,14 @@ class Configurator extends Object
 
 	/**
 	 * @return Nette\Loaders\RobotLoader
+	 * @throws Nette\NotSupportedException if RobotLoader is not available
 	 */
 	public function createRobotLoader()
 	{
+		if (!class_exists('Nette\Loaders\RobotLoader')) {
+			throw new Nette\NotSupportedException('RobotLoader not found, do you have `nette/robot-loader` package installed?');
+		}
+
 		$loader = new Nette\Loaders\RobotLoader;
 		$loader->setCacheStorage(new Nette\Caching\Storages\FileStorage($this->getCacheDirectory()));
 		$loader->autoRebuild = $this->parameters['debugMode'];


### PR DESCRIPTION
RobotLoader is used only in Configurator, the only change required is to add exception with appropriate message.  

(Relates to #4)
