### PR TITLE
Cache key of generated container should depend on PHP version

### DIFF
--- a/src/Bootstrap/Configurator.php
+++ b/src/Bootstrap/Configurator.php
@@ -213,7 +213,7 @@ class Configurator extends Object
 			$this->parameters['debugMode']
 		);
 		$class = $loader->load(
-			[$this->parameters, $this->files],
+			[$this->parameters, $this->files, PHP_VERSION_ID - PHP_RELEASE_VERSION],
 			[$this, 'generateContainer']
 		);
 


### PR DESCRIPTION
Container generated on PHP 7 is invalid on PHP 5 due to return types.

Line hint: https://github.com/nette/bootstrap/blob/27b35e20a8c9d19e2d040a85112adc53455ded1b/src/Bootstrap/Configurator.php#L215-L218