### PR TITLE
Fixes invalid handling of `DI\Compiler::compile()` return values

### DIFF
--- a/src/Bootstrap/Configurator.php
+++ b/src/Bootstrap/Configurator.php
@@ -261,7 +261,7 @@ class Configurator
 		$this->onCompile($this, $compiler);
 
 		$classes = $compiler->compile();
-		return implode("\n", $fileInfo) . "\n\n" . $classes;
+		return implode("\n", $fileInfo) . "\n\n" . (is_array($classes) ? implode("\n\n\n", $classes) : $classes);
 	}
 
 


### PR DESCRIPTION
The handling of return values of the call to `DI\Compiler::compile` inside method `Configurator::generateContainer` is incomplete and fails when the call returns an array of `PhpGenerator\ClassType`, which it returns as the default when being called with no arguments, as implemented on [line 263 of `Nette\Configurator`](https://github.com/nette/bootstrap/blob/master/src/Bootstrap/Configurator.php#L263).

This commit provides a valid FIX for both possible return value types according to the annotation in `DI\Compiler`:
```
@return Nette\PhpGenerator\ClassType[]|string
```