### PR TITLE
Don't set consoleMode for php built-in webserver

### DIFF
--- a/src/Bootstrap/Configurator.php
+++ b/src/Bootstrap/Configurator.php
@@ -163,7 +163,7 @@ class Configurator
 			'vendorDir' => $loaderRc ? dirname($loaderRc->getFileName(), 2) : null,
 			'debugMode' => $debugMode,
 			'productionMode' => !$debugMode,
-			'consoleMode' => PHP_SAPI === 'cli',
+			'consoleMode' => PHP_SAPI === 'cli' && php_sapi_name() !== 'cli-server',
 		];
 	}
 


### PR DESCRIPTION
- bug fix
- BC break? should not be

In case app is accessed via php built-in webserver (`php -S 127.0.0.1:80 -t www www/index.php`) then `PHP_SAPI === 'cli'` which means console mode is turned on