### PR TITLE
Fix VendorDir in case of application was called by Composer task.

### DIFF
--- a/src/Bootstrap/Configurator.php
+++ b/src/Bootstrap/Configurator.php
@@ -157,10 +157,14 @@ class Configurator
 		$last = end($trace);
 		$debugMode = static::detectDebugMode();
 		$loaderRc = class_exists(ClassLoader::class) ? new \ReflectionClass(ClassLoader::class) : null;
+		$vendorDir = $loaderRc ? dirname($loaderRc->getFileName(), 2) : null;
+		if ($vendorDir !== null && PHP_SAPI === 'cli' && strncmp($vendorDir, 'phar://', 7) === 0) {
+			$vendorDir = (string) preg_replace('/^(.+?\/vendor)(.*)$/', '$1', $trace[0]['file']);
+		}
 		return [
 			'appDir' => isset($trace[1]['file']) ? dirname($trace[1]['file']) : null,
 			'wwwDir' => isset($last['file']) ? dirname($last['file']) : null,
-			'vendorDir' => $loaderRc ? dirname($loaderRc->getFileName(), 2) : null,
+			'vendorDir' => $vendorDir,
 			'debugMode' => $debugMode,
 			'productionMode' => !$debugMode,
 			'consoleMode' => PHP_SAPI === 'cli',


### PR DESCRIPTION
- bug fix
- BC break? no (i am not sure)

In case of application was called by Composer task (by command `composer dump`) and in `composer.json` is this section:

```json
"scripts": {
   "post-autoload-dump": "Baraja\\PackageManager\\PackageRegistrator::composerPostAutoloadDump"
}
```

Parameter `vendorDir` can be fake, because Terminal composer starting in file `phar:///usr/local/Cellar/composer/1.6.4/bin/composer/vendor` (my local configuration) and `vendorDir` is this path (with does not make sense).

I think in this case path `vendorDir` should be rewrited to real path by inspecting of current debug backtrace, because current Configuration class is using real disk path.

Some example:

<img width="876" alt="Snímek obrazovky 2020-04-30 v 10 15 12" src="https://user-images.githubusercontent.com/4738758/80688834-b736ba00-8acc-11ea-8a9c-d23fc12cbee0.png">

What do you think about?

Thanks!