### PR TITLE
DetectDebugMode: Add native support for CloudFlare

### DIFF
--- a/src/Bootstrap/Configurator.php
+++ b/src/Bootstrap/Configurator.php
@@ -316,7 +316,7 @@ class Configurator
 	 */
 	public static function detectDebugMode($list = null): bool
 	{
-		$addr = $_SERVER['REMOTE_ADDR'] ?? php_uname('n');
+		$addr = ($_SERVER['HTTP_CDN_LOOP'] ?? '') === 'cloudflare' ? $_SERVER['HTTP_CF_CONNECTING_IP'] : $_SERVER['REMOTE_ADDR'] ?? php_uname('n');
 		$secret = is_string($_COOKIE[self::COOKIE_SECRET] ?? null)
 			? $_COOKIE[self::COOKIE_SECRET]
 			: null;


### PR DESCRIPTION
- new feature
- BC break? no

I think Tracy should support Cloudflare natively.

The real IP address can be detected by `HTTP_CF_CONNECTING_IP` and not by `HTTP_X_FORWARDED_FOR`, because `CF` keys is generated safely way by Cloudflare.

More info: https://forum.nette.org/cs/33229-tracy-debugger-nefunguje-po-pripojeni-na-cloudflare#p210213 (Czech language)

Example:

![Snímek obrazovky 2020-05-07 v 9 48 07](https://user-images.githubusercontent.com/4738758/81268293-10ac6500-9048-11ea-8d6e-ad1e37e7b972.png)

Thanks.