### PR TITLE
Proposal: Configurator::setDebugMode() should throw an exception when Debugger is already enabled

### DIFF
--- a/src/Bootstrap/Configurator.php
+++ b/src/Bootstrap/Configurator.php
@@ -84,6 +84,10 @@ class Configurator
 	 */
 	public function setDebugMode($value)
 	{
+		if (Tracy\Debugger::isEnabled()) {
+			throw new InvalidStateException("You cannot set debug mode after starting debugger. ");
+		}
+
 		if (is_string($value) || is_array($value)) {
 			$value = static::detectDebugMode($value);
 		} elseif (!is_bool($value)) {


### PR DESCRIPTION
- developer experience improvement
- BC break? no
- doc PR: -

Yesterday I've spent some time figuring out how to enable Tracy debugger in my app. In sandbox there is legendary commented line with invalid IP setting the debug mode so people can uncomment it and change it to their needs. Unfortunately, I've removed this line and when I came to this project after a while I've called `Configurator::setDebugMode()` after `Configurator::enableTracy()`. This of course didn't work because `debugMode` was passed to Tracy before I've changed it.

My proposal is to throw an exception when debugger is already running.