### PR TITLE
Extensions improvements

### DIFF
--- a/src/Bootstrap/Extensions/ConstantsExtension.php
+++ b/src/Bootstrap/Extensions/ConstantsExtension.php
@@ -10,13 +10,22 @@ declare(strict_types=1);
 namespace Nette\Bootstrap\Extensions;
 
 use Nette;
-
+use Nette\Schema\Expect;
 
 /**
  * Constant definitions.
  */
 final class ConstantsExtension extends Nette\DI\CompilerExtension
 {
+	public function getConfigSchema(): Nette\Schema\Schema
+	{
+		return Expect::arrayOf(
+			Expect::anyOf(Expect::scalar(), Expect::null(), Expect::array()),
+			Expect::string(),
+		);
+	}
+
+
 	public function loadConfiguration()
 	{
 		foreach ($this->getConfig() as $name => $value) {

--- a/src/Bootstrap/Extensions/PhpExtension.php
+++ b/src/Bootstrap/Extensions/PhpExtension.php
@@ -20,7 +20,7 @@ final class PhpExtension extends Nette\DI\CompilerExtension
 {
 	public function getConfigSchema(): Nette\Schema\Schema
 	{
-		return Expect::arrayOf(Expect::scalar()->dynamic());
+		return Expect::arrayOf(Expect::scalar()->dynamic()->nullable());
 	}
 
 

--- a/src/Bootstrap/Extensions/PhpExtension.php
+++ b/src/Bootstrap/Extensions/PhpExtension.php
@@ -20,7 +20,10 @@ final class PhpExtension extends Nette\DI\CompilerExtension
 {
 	public function getConfigSchema(): Nette\Schema\Schema
 	{
-		return Expect::arrayOf(Expect::scalar()->dynamic()->nullable());
+		return Expect::arrayOf(
+			Expect::scalar()->dynamic()->nullable(),
+			Expect::string(),
+		);
 	}
 
 

--- a/tests/Bootstrap/ConstantsExtension.phpt
+++ b/tests/Bootstrap/ConstantsExtension.phpt
@@ -16,6 +16,12 @@ $compiler->addConfig([
 	'constants' => [
 		'a' => 'hello',
 		'A' => 'WORLD',
+		'b' => 123,
+		'c' => 1.23,
+		'd' => true,
+		'e' => false,
+		'f' => null,
+		'g' => [],
 	],
 ]);
 eval($compiler->compile());
@@ -25,3 +31,9 @@ $container->initialize();
 
 Assert::same('hello', a);
 Assert::same('WORLD', A);
+Assert::same(123, b);
+Assert::same(1.23, c);
+Assert::same(true, d);
+Assert::same(false, e);
+Assert::same(null, f);
+Assert::same([], g);

--- a/tests/Bootstrap/PhpExtension.phpt
+++ b/tests/Bootstrap/PhpExtension.phpt
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$compiler = new DI\Compiler;
+$compiler->setClassName('Container');
+$compiler->addExtension('php', new Nette\Bootstrap\Extensions\PhpExtension());
+$compiler->addConfig([
+	'php' => [
+		'date.timezone' => 'Europe/Rome',
+	],
+]);
+eval($compiler->compile());
+
+ini_set('date.timezone', 'Europe/Prague');
+
+$container = new Container;
+$container->initialize();
+
+Assert::same('Europe/Rome', ini_get('date.timezone'));

--- a/tests/Bootstrap/PhpExtension.phpt
+++ b/tests/Bootstrap/PhpExtension.phpt
@@ -15,6 +15,7 @@ $compiler->addExtension('php', new Nette\Bootstrap\Extensions\PhpExtension());
 $compiler->addConfig([
 	'php' => [
 		'date.timezone' => 'Europe/Rome',
+		'exit_on_timeout' => null,
 	],
 ]);
 eval($compiler->compile());


### PR DESCRIPTION
- bug fix etc.
- BC break? no
- doc PR:  not needed?

PhpExtension is tested, validates key is string (required by ini_set) and allows null (fixes currently dead condition)
ConstantsExtensions validates name and value contains only types allowed by define() and tests all valid cases